### PR TITLE
Fix: Use tracefile size/count to prevent storing the trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ### dntrace
 
 This tool traces .NET Core runtime events, displays them in real-time, and
-aggregates them in memory to produce statistics. No events are recorded to
-disk, which provides for lightweight monitoring that can be sustained for long
-time intervals.
+aggregates them in memory to produce statistics. Only a small amount of events
+is stored on the disk as a cache (at most 5M per-cpu), which provides for
+lightweight monitoring that can be sustained for long time intervals.
 
 > This tool is not production-ready; use at your own risk. It was briefly
 > tested with .NET Core 2.0 on Fedora. Other distributions or versions might

--- a/dntrace.sh
+++ b/dntrace.sh
@@ -48,30 +48,31 @@ function destroy {
 }
 
 function record {
-    sudo lttng create $session --live --no-output
+    sudo lttng create $session --live
+    sudo lttng enable-channel --tracefile-size 1M --tracefile-count 5 -u chan
 
     if (( opt_pid )); then
         sudo lttng track --userspace --session $session --pid $pid
     fi
 
-    sudo lttng add-context --userspace --type vpid
-    sudo lttng add-context --userspace --type vtid
-    sudo lttng add-context --userspace --type procname
+    sudo lttng add-context --userspace --type vpid -c chan
+    sudo lttng add-context --userspace --type vtid -c chan
+    sudo lttng add-context --userspace --type procname -c chan
 
     if (( gc_enabled )); then
-        sudo lttng enable-event --userspace --tracepoint DotNETRuntime:GCStart*
-        sudo lttng enable-event --userspace --tracepoint DotNETRuntime:GCEnd*
-        sudo lttng enable-event --userspace --tracepoint DotNETRuntime:GCTriggered
+        sudo lttng enable-event --userspace -c chan --tracepoint DotNETRuntime:GCStart*
+        sudo lttng enable-event --userspace -c chan --tracepoint DotNETRuntime:GCEnd*
+        sudo lttng enable-event --userspace -c chan --tracepoint DotNETRuntime:GCTriggered
     fi
     if (( heap_enabled )); then
-        sudo lttng enable-event --userspace --tracepoint DotNETRuntime:GCHeapStats*
+        sudo lttng enable-event --userspace -c chan --tracepoint DotNETRuntime:GCHeapStats*
     fi
     if (( alloc_enabled )); then
-        sudo lttng enable-event --userspace --tracepoint \
+        sudo lttng enable-event --userspace -c chan --tracepoint \
                                 DotNETRuntime:GCAllocationTick*
     fi
     if (( exc_enabled )); then
-        sudo lttng enable-event --userspace --tracepoint DotNETRuntime:Exception*
+        sudo lttng enable-event --userspace -c chan --tracepoint DotNETRuntime:Exception*
     fi
 
     sudo lttng start $session


### PR DESCRIPTION
The --no-output flag is ignored in live mode, the traces are actually
stored by the relay in `~/lttng-traces/<hostname>/<session-name>`. In
live mode we need some storage because the client asks the relay for
data and the relay cannot store the trace in memory for an arbitrary
amount of time.

A way to prevent the trace from always increasing in size is to use the
`--tracefile-size` and `--tracefile-count` options to limit the size of the
tracefiles on disk, the relay will automatically overwrite older files a
keep a ring-buffer of tracefiles on disk. If the client is too slow to
fetch the data before it is overwritten, we will see lost packets, so we
need to increase the amount we keep.

In this patch, we keep at most 5 files of 1M of trace for each CPU, if
it is not enough, it will be easy to change.

Signed-off-by: Julien Desfossez <jdesfossez@efficios.com>